### PR TITLE
Fix multiple attachments case

### DIFF
--- a/app/jiraApi.js
+++ b/app/jiraApi.js
@@ -44,12 +44,9 @@ class JiraApi {
 
 	async _downloadAttachment(issueKey, attachment) {
 		const imagesDir = `./images/${issueKey}`;
-		if(fs.existsSync(imagesDir)) {
-			// Images had already been downloaded, no need to download again
-			return;
+		if(!fs.existsSync(imagesDir)) {
+			fs.mkdirSync(imagesDir);
 		}
-		fs.mkdirSync(imagesDir);
-
 		const response = await fetch(attachment.content, HttpUtils.getAuthHeader(this.jiraSettings.user, this.jiraSettings.password));
 
         await new Promise((resolve, reject) => {


### PR DESCRIPTION
With the current implementation, it is not possible to migrate test cases with multiple attachments.

This fix helps to load multiple attachments for a test case.

@pelizza @otaviomedeirossb @fnmunhoz @johnathafelix please, review ;)